### PR TITLE
In case of status green the regexp translates it to geen.

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -105,9 +105,8 @@ get_status() {
 }
 
 get_vals() {
-    #name=`grep cluster_name ${filename} | awk '{print $3}' | sed 's|[\r",]||g'`
-    name=`grep cluster_name ${filename} | awk 'BEGIN { FS = " : " } ; {print $2}' | sed 's|[\r",]||g'`
-    status=`grep status ${filename} | awk '{print $3}' | sed 's|[\r",]||g'`
+    name=$(grep '"cluster_name" :' ${filename} | awk -F '"' '{print $4}')
+    status=$(grep '"status" :' ${filename} | awk -F '"' '{print $4}')
     timed_out=`grep timed_out ${filename} | awk '{print $3}' | sed 's|[\r",]||g'`
     number_nodes=`grep number_of_nodes ${filename} | awk '{print $3}' | sed 's|[\r",]||g'`
     number_data_nodes=`grep number_of_data_nodes ${filename} | awk '{print $3}' | sed 's|[\r",]||g'`


### PR DESCRIPTION
Tried on a ELK instance (elasticsearch 2.1.0 and so on) and I wasn't understanding why nagios returned always CRITICAL. Then I found out that in case of 'status' the regexp provides to remove the 'r' char, so green becomes geen.
Don't know if it's related to my box (I'm using a FreeBSD 10.2), but this will work on Linux as well.