### PR TITLE
Make check go green if in warning

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -67,6 +67,8 @@ print_help() {
     echo "    Turns on authentication mode with default credentials."
     echo "  -c/--ca-certificate)"
     echo "    Uses the provided CA certificate."
+    echo "  -k/--ok-on-yellow)"
+    echo "     Exit with OK state if the cluster is yellow."
     exit $ST_UK
 }
 
@@ -82,6 +84,10 @@ while test -n "$1"; do
             ;;
         --hostname|-H)
             hostname=$2
+            shift
+            ;;
+        --ok-on-yellow|-k)
+            ok_on_yellow="True"
             shift
             ;;
         --secure|-s)
@@ -167,8 +173,13 @@ get_vals() {
         NAGSTATUS="CRITICAL"
         EXST=$ST_CR
     elif [ "$status" = "yellow" ]; then
-        NAGSTATUS="WARNING"
-        EXST=$ST_WR
+        if [[ "$ok_on_yellow" == "" ]]; then
+            NAGSTATUS="WARNING"
+            EXST=$ST_WR
+	else
+            NAGSTATUS="OK"
+            EXST=$ST_OK
+        fi 
     elif [ "$status" = "green" ]; then
         NAGSTATUS="OK"
         EXST=$ST_OK


### PR DESCRIPTION
 - Rebase of #10
 - Adds two new arguments:
  - "-k" and "--ok-on-yellow"

Example output:
<pre>
$ ./check_elasticsearch -P 9199 --ok-on-yellow; echo $?
OK - elasticsearch (not_real) is running. status: yellow; timed_out: false;
number_of_nodes: 1; number_of_data_nodes: 1; active_primary_shards: 31;
active_shards: 31; relocating_shards: 0; initializing_shards: 0;
delayed_unassigned_shards: 0; unassigned_shards: 30  |
'active_primary'=31 'active'=31 'relocating'=0 'init'=0 'delay_unass'=0
'unass'=30
0
</pre>