### PR TITLE
remove lingering temp file if connection failed

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -243,6 +243,7 @@ fi
 get_status
 if [ ! -s "$filename" ]; then
     echo "CRITICAL - Could not connect to server $hostname"
+    rm -f "$filename"
     exit $ST_CR
 else
     get_vals


### PR DESCRIPTION
Before the check used a random filename (mktemp), the temp filename was always the same so the 0 byte file would eventually be overwritten and removed upon success.

Now the file name is different each time, to the empty files stack up.