### PR TITLE
fix private_key/authentication method condition

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -187,7 +187,7 @@ get_status() {
     filename=$(mktemp -u -p "$output_dir" --suffix="-${PROGNAME}")
 
     # If authentication via private key ist defined
-    if [ -n ${private_key} ]
+    if [ -n "${private_key}" ]
     then
        wget -q -t 3 -T 3 ${cert} ${private_key} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy}
     else


### PR DESCRIPTION
The condition does not evaluate properly without the added quotes, rendering user & password authentication method not working properly.