### PR TITLE
fix parameters for when not using auth

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -190,8 +190,10 @@ get_status() {
     if [ -n "${private_key}" ]
     then
        wget -q -t 3 -T 3 ${cert} ${private_key} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy}
-    else
+    elif [ "${authentication}" = "True" ]; then
        wget -q -t 3 -T 3 ${ca_cert} ${user} ${pass} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy}
+    else
+       wget -q -t 3 -T 3 ${ca_cert} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy}
     fi
 }
 


### PR DESCRIPTION
When neither user/password or auth parameters are given we do not want the default $user and $pass parameters to be passed as urls to wget. It tries to resolve them in order (potentially leaking the default user and password in a DNS query).

This fixes that by adding a condition on the already present $authentication flag and using that to select a commandline without those $user/$pass variables.