### PR TITLE
Fix syntax error in Icinga2 command definition

### DIFF
--- a/check_elasticsearch.conf
+++ b/check_elasticsearch.conf
@@ -36,7 +36,7 @@ object CheckCommand "elastic-search" {
             description = "Uses the provided CA certificate."
         }
         "--use-jq" = {
-            value = "$elasticsearch_use_jq"
+            value = "$elasticsearch_use_jq$"
             description = "Uses jq command to parse the elastic output."
         }
     }


### PR DESCRIPTION
- add closing macro marker