### PR TITLE
Make wget work better with elasticsearch 8

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -227,7 +227,7 @@ get_status() {
     then
        wget -t 3 -T 3 ${cert} ${private_key} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
     elif [ "${authentication}" = "True" ]; then
-       wget -t 3 -T 3 ${ca_cert} ${user} ${pass}  $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
+       wget -t 3 -T 3 ${ca_cert} ${user} ${pass} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
     else
        wget -t 3 -T 3 ${ca_cert} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
     fi

--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -192,6 +192,7 @@ done
 if [ "$authentication" = "True" ]; then
     pass="--password=${pass}"
     user="--user=${user}"
+    wget_add_args+=("--auth-no-challenge")
 fi
 
 if [ "$use_ca" = "True" ]; then
@@ -226,7 +227,7 @@ get_status() {
     then
        wget -t 3 -T 3 ${cert} ${private_key} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
     elif [ "${authentication}" = "True" ]; then
-       wget -t 3 -T 3 ${ca_cert} --auth-no-challenge ${user} ${pass}  $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
+       wget -t 3 -T 3 ${ca_cert} ${user} ${pass}  $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
     else
        wget -t 3 -T 3 ${ca_cert} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
     fi

--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -226,7 +226,7 @@ get_status() {
     then
        wget -t 3 -T 3 ${cert} ${private_key} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
     elif [ "${authentication}" = "True" ]; then
-       wget -t 3 -T 3 ${ca_cert} ${user} ${pass} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
+       wget -t 3 -T 3 ${ca_cert} --auth-no-challenge ${user} ${pass}  $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
     else
        wget -t 3 -T 3 ${ca_cert} $scheme://${hostname}:${port}/${status_page}?pretty=true -O ${filename} ${proxy} ${wget_add_args[@]}
     fi


### PR DESCRIPTION
Always send `--auth-no-challenge` when authentication is in use: it's faster, and some combinations of wget and elasticsearch will not authenticate right (wget 1.21 on Debian 12 and Elasticsearch 8.11 at least).